### PR TITLE
feat: add search

### DIFF
--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,0 +1,122 @@
+{{- /* Special Thanks: https://maku77.github.io/p/p4n5m3i/ */}}
+
+{{- /* エスケープ処理（改行を空白化、前後の空白削除、連続する空白を集約） */}}
+{{- define "escape" }}
+  {{- trim (replace . "\n" " ") " " | replaceRE " +" " " -}}
+{{- end }}
+
+{{ define "main" }}
+  <style>
+    input {
+      color: #189;
+      font-size: 1.2em;
+      font-weight: bolder;
+    }
+    input::-webkit-input-placeholder {
+      color: orange;
+    }
+    #result {
+      margin: 1em;
+    }
+    .item_title {
+      text-decoration: none;
+      color: #3ab;
+      font-weight: bolder;
+    }
+    .item_excerpt {
+      margin: 0.5em 2em 1em;
+      padding: 0.5em;
+      border: dashed 1px lightgray;
+      font-size: smaller;
+    }
+    .item_excerpt b {
+      background: #389;
+    }
+  </style>
+
+<h1>{{ .Page.Title }}</h1>
+<input onkeyup="search(this.value)" size="15" autocomplete="off" autofocus placeholder="検索ワード" />
+<span id="inputWord"></span> <span id="resultCount"></span>
+<div id="result"></div>
+
+<script>
+// 検索用のインデックスデータ
+const data = [
+{{- range $index, $page := .Site.Pages }}
+  {
+    url: {{ $page.RelPermalink }},
+    title: {{ $page.Title }},
+    date: {{ $page.Date }},
+    body: {{ template "escape" (printf "%s %s" $page.Title $page.Plain) }}
+  },
+{{- end }}
+];
+</script>
+
+<script>
+function search(query) {
+  const result = searchData(query);
+  const html = createHtml(result);
+  showResult(html);
+  showResultCount(result.length, data.length);
+}
+
+function searchData(query) {
+  // 検索にヒットした情報を下記のような配列として格納していく
+  // [データのインデックス, 文字の開始位置, 文字の終了位置]
+  const result = [];
+
+  query = query.trim();
+  if (query.length < 1) {
+    return result;
+  }
+  const re = new RegExp(query, 'i');
+  for (let i = 0; i < data.length; ++i) {
+    const pos = data[i].body.search(re);
+    if (pos != -1) {
+      result.push([i, pos, pos + query.length]);
+    }
+  }
+  return result;
+}
+
+function createHtml(result) {
+  const htmls = [];
+  for (let i = 0; i < result.length; ++i) {
+    const dataIndex = result[i][0];
+    const startPos = result[i][1];
+    const endPos = result[i][2];
+    const url = data[dataIndex].url;
+    const title = data[dataIndex].title;
+    const body = data[dataIndex].body;
+    htmls.push(createEntry(url, title, body, startPos, endPos));
+  }
+  return htmls.join('');
+}
+
+function createEntry(url, title, body, startPos, endPos) {
+  return '<div class="item">' +
+      '<a class="item_title" href="' + url + '">' + title + '</a>' +
+      '<div class="item_excerpt">' + excerpt(body, startPos, endPos) + '</div>' +
+      '</div>';
+}
+
+function excerpt(body, startPos, endPos) {
+  return [
+    body.substring(startPos - 30, startPos),
+    '<b>', body.substring(startPos, endPos), '</b>',
+    body.substring(endPos, endPos + 200)
+  ].join('');
+}
+
+function showResult(html) {
+  const el = document.getElementById('result');
+  el.innerHTML = html;
+}
+
+function showResultCount(count, total) {
+  const el = document.getElementById('resultCount');
+  el.innerHTML = '<b>' + count + '</b> 件見つかりました（' + total + '件中）';
+}
+</script>
+{{ end }}


### PR DESCRIPTION
## `posts/search.md`

```md
---
title: "サイト内全文検索"
layout: search
_build: { list: false }
---
```

## `hugo.toml`

```toml
[menu]
  [[menu.main]]
  identifier = "search"
  name = "Search"
  url = "/search/"
```

## sample image

<img width="525" alt="スクリーンショット 2023-05-30 23 51 46" src="https://github.com/kemokemo/hugo-theme-m10c/assets/12206485/d939dc13-2ece-4371-9a47-3fc0abf3c89c">
